### PR TITLE
Use os.path.join to join file/folder paths

### DIFF
--- a/main.py
+++ b/main.py
@@ -78,7 +78,7 @@ def parse(asset):
 
 def get_files(path):
     current_folders = [folder for folder in os.listdir(path) if os.path.isdir(os.path.join(path, folder))]
-    all_files = [path + file for file in os.listdir(path) if os.path.isfile(os.path.join(path, file)) and file.endswith(".uexp")]
+    all_files = [os.path.join(path, file) for file in os.listdir(path) if os.path.isfile(os.path.join(path, file)) and file.endswith(".uexp")]
     for current_folder in current_folders:
         full_folder = os.path.join(path, current_folder)
         files = [os.path.join(full_folder, file) for file in os.listdir(full_folder)

--- a/main.py
+++ b/main.py
@@ -77,15 +77,15 @@ def parse(asset):
 
 
 def get_files(path):
-    current_folders = [folder for folder in os.listdir(path) if os.path.isdir(path + folder)]
-    all_files = [path + file for file in os.listdir(path) if os.path.isfile(path + file) and file.endswith(".uexp")]
+    current_folders = [folder for folder in os.listdir(path) if os.path.isdir(os.path.join(path, folder))]
+    all_files = [path + file for file in os.listdir(path) if os.path.isfile(os.path.join(path, file)) and file.endswith(".uexp")]
     for current_folder in current_folders:
-        full_folder = path + current_folder + "\\"
-        files = [full_folder + file for file in os.listdir(full_folder)
-                 if os.path.isfile(full_folder + file) and file.endswith(".uexp")]
+        full_folder = os.path.join(path, current_folder)
+        files = [os.path.join(full_folder, file) for file in os.listdir(full_folder)
+                 if os.path.isfile(os.path.join(full_folder, file)) and file.endswith(".uexp")]
         for folder in os.listdir(full_folder):
-            if os.path.isdir(full_folder + folder):
-                files.extend(get_files(full_folder + folder + "\\"))
+            if os.path.isdir(os.path.join(full_folder, folder)):
+                files.extend(get_files(os.path.join(full_folder, folder)))
         all_files.extend(files)
     return all_files
 


### PR DESCRIPTION
Using Python 3.10 file/folder joins were broken on my Windows machine.  Updating uses of "+" to os.path.join() resolved the issue.